### PR TITLE
Refactors beta to optimise and adds test

### DIFF
--- a/src/PSI_Clay_Calc.py
+++ b/src/PSI_Clay_Calc.py
@@ -247,8 +247,24 @@ def wedge_factor(z, D):
 
 
 def beta(z, D):
-    for i in range(len(z)):
-        return np.min((np.pi / 2, np.arccos(1 - (2 * z[i]) / D[i])))
+    """
+    Calculates beta for use when calculating the wedging factor
+
+    Beta is the angle depicted in Fig. 4-12 of DNV-RP-F114 (2021)
+
+    Parameters
+    ----------
+    z : float | np.ndarray
+        pipe penetration (m)
+    D: float | np.ndarray
+        overall diameter (m)
+
+    Returns
+    -------
+    beta : float | np.ndarray
+        angle beta from Fig. 4-12 of DNV-RP-F114 (2021)
+    """
+    return np.where(z <= D / 2, np.arccos(1 - (2 * z) / D), np.pi / 2)
 
 
 def OCR(W_hydro, W_case):

--- a/tests/test_PSI_Clay_Calc.py
+++ b/tests/test_PSI_Clay_Calc.py
@@ -1,6 +1,7 @@
 from math import pi
 
 import pytest
+import numpy as np
 
 import src.PSI_Clay_Calc as psi
 
@@ -75,3 +76,14 @@ def test_W_sub():
 
     # mocked__cylinder_weight.assert_has_calls(calls, any_order=True)
     assert actual == pytest.approx(expected)
+
+
+def test_beta():
+
+    D = np.array([1, 1])
+    z = np.array([0.1, 0.6])
+
+    actual = psi.beta(z, D)
+    expected = np.array([0.64350111, pi / 2])
+
+    np.testing.assert_array_almost_equal(actual, expected)

--- a/tests/test_PSI_Clay_Calc.py
+++ b/tests/test_PSI_Clay_Calc.py
@@ -80,10 +80,10 @@ def test_W_sub():
 
 def test_beta():
 
-    D = np.array([1, 1])
-    z = np.array([0.1, 0.6])
+    D = np.array([1, 1, 1])
+    z = np.array([0.1, 0.6, 0.5])
 
     actual = psi.beta(z, D)
-    expected = np.array([0.64350111, pi / 2])
+    expected = np.array([0.64350111, pi / 2, pi / 2])
 
     np.testing.assert_array_almost_equal(actual, expected)


### PR DESCRIPTION
Numpy is optimised for array functions, so it's faster to use `np.where()` instead of an `if-else` construct.